### PR TITLE
chore(devcontainer): mount host ~/.claude, ~/.claude.json, ~/.gitconfig

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -52,6 +52,9 @@
     }
   },
   "mounts": [
-    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
+    "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind",
+    "source=${localEnv:HOME}/.claude.json,target=/home/vscode/.claude.json,type=bind",
+    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind"
   ]
 }


### PR DESCRIPTION
## Summary
- Bind-mount `~/.gitconfig`, `~/.claude.json`, and `~/.claude` from the host into the devcontainer.
- Lets a Claude session dispatched into this devcontainer (from the fleet orchestrator) share auth and memory with the host instead of starting blank.

## Test plan
- [x] `devcontainer up` succeeds
- [x] `ls /home/vscode/.claude` inside the container shows host contents
- [x] `gh` is installed (apt-packages feature) and authenticates from inside

🤖 Generated with [Claude Code](https://claude.com/claude-code)