### PR TITLE
chore(deps): set Renovate mode to full to override Mend Silent default

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "mode": "full",
   "extends": [
     "config:recommended",
     ":dependencyDashboard",


### PR DESCRIPTION
## Summary
One-line addition: `"mode": "full"` in `renovate.json`. Overrides Mend Cloud's default Silent mode so Renovate actually creates PRs and the Dependency Dashboard issue in GitHub.

## Why
After the original migration ([#61](https://github.com/bharat/homeassistant-bromic-smart-heat-link/pull/61)) merged, 13+ hours passed with zero Renovate-bot activity in GitHub. The Mend developer portal showed:

> **Dependency Updates (Renovate): Silent**
> Renovate plan: Community (Free)

…with three updates queued for manual approval. The fix per Renovate maintainer guidance ([discussion #39198](https://github.com/renovatebot/renovate/discussions/39198), [Mend hosted apps config](https://docs.renovatebot.com/mend-hosted/hosted-apps-config/)) is a top-level `mode: full` in `renovate.json`.

## Test plan
- Merge.
- On Mend's next scheduled run (within ~1 hour), expect Renovate to:
  - Open the Dependency Dashboard issue.
  - Open the queued GitHub-Actions group PR (`actions/checkout` patch + the held v6 major).
  - Open the `python 3.13 → 3.14` devcontainer PR if the 14-day age gate has cleared.

## Fleet impact
Same line will be added to control4 #48, triad-ams #110, lockly #82 (the still-open migration PRs) before they merge, so they don't repeat this discovery.