### PR TITLE
chore(deps): block Python upgrades in Renovate until HA pin is upgraded

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,11 @@
       "description": "homeassistant is upgraded in lockstep with pytest-homeassistant-custom-component (see AGENTS.md fleet policy). Let helper bumps drive the HA upgrade rather than bumping homeassistant directly."
     },
     {
+      "matchDepNames": ["python", "mcr.microsoft.com/devcontainers/python"],
+      "enabled": false,
+      "description": "Python upgrades blocked until bromic's HA pin (currently homeassistant==2025.2.4) is upgraded. The stale HA pulls in home-assistant-bluetooth==1.13.0 which has no Python 3.14 wheels, so any Python 3.14 bump fails pip resolution at CI time. Re-enable (delete this rule) once requirements.txt's homeassistant pin is on a release with Python 3.14 support."
+    },
+    {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "platformAutomerge": true


### PR DESCRIPTION
## Summary
Adds a `packageRules` entry that disables Renovate for `python` (in `setup-python` actions) and `mcr.microsoft.com/devcontainers/python` (in `.devcontainer/devcontainer.json`).

## Why
Renovate keeps re-proposing the Python 3.13 → 3.14 bump:
- First in PR #63 (closed) — `chore(deps): update github actions` group
- Then re-smuggled inside PR #66 (still open) — `chore(deps): pin dependencies` (Renovate reused the same `renovate/github-actions` branch which still carried the python diff)

Both fail at CI with:
```
ERROR: Could not find a version that satisfies the requirement
  home-assistant-bluetooth==1.13.0 (from homeassistant)
  ... 1.13.0 Requires-Python >=3.11,<3.14
```

`requirements.txt` is on `homeassistant==2025.2.4` (Feb 2025), whose transitive `home-assistant-bluetooth==1.13.0` has no Python 3.14 wheels. Until that HA pin is upgraded, no Python 3.14 bump can land.

Blocking the Python bump in `renovate.json` is the durable fix — closing the PRs alone doesn't help because Renovate re-evaluates on every scan.

## Follow-up
**Delete this packageRule once `requirements.txt`'s `homeassistant` pin is upgraded to a release with Python 3.14 support** (e.g. `2026.5.x`, matching the rest of the fleet). The bromic HA upgrade is the real next-step work and is tracked separately.

## Test plan
- Merge.
- On the next Renovate scan, expect: PR #66's python diff to be dropped or PR #66 itself to be closed by Renovate. The `pin dependencies` portion (SHA pins) will be re-proposed as a clean PR.