### PR TITLE
test: add baseline smoke test asserting predictable setup-failure path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+permissions: {}
+
+jobs:
+  pytest:
+    name: "Pytest"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Install requirements
+        run: python3 -m pip install -r requirements.txt
+
+      - name: Run tests
+        run: python3 -m pytest tests/

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -23,3 +23,17 @@ keep-runtime-typing = true
 
 [lint.mccabe]
 max-complexity = 25
+
+[lint.per-file-ignores]
+# Tests use asserts, magic numbers, private internals, and pytest fixture
+# injection that violates the global ANN/ARG rules in benign ways.
+"tests/**" = [
+    "S101",     # assert statements
+    "PLR2004",  # magic value used in comparison
+    "SLF001",   # private member accessed
+    "ANN001",   # missing-type-function-argument (pytest fixtures)
+    "ANN201",   # missing-return-type-undocumented-public-function
+    "ARG001",   # unused-function-argument (pytest fixture injection)
+    "ARG002",   # unused-method-argument
+    "D213",     # multi-line-docstring-summary-second-line (style)
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pip>=26.1.1
 ruff==0.15.12
 pre_commit==4.6.0
 serial==0.0.97
+pytest-homeassistant-custom-component==0.13.214

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for the Bromic Smart Heat Link integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Test fixtures for Bromic Smart Heat Link."""
+
+import pytest
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Make HA discover the integration under custom_components/."""
+    return

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,73 @@
+"""
+Smoke test for the Bromic Smart Heat Link integration.
+
+Verifies that the integration loads under the currently-pinned Home Assistant
+release and fails in the documented, predictable way (`ConfigEntryNotReady`
+→ entry state `SETUP_RETRY`) when no real Bromic Smart Heat Link bridge is
+reachable. CI has no serial hardware, so this is the natural failure path.
+
+This is a **baseline** test for the fleet's "auto-merge HA-stack major bumps
+only if smoke test passes" policy (see fleet memory
+`feedback_renovate_pr_handling_policy.md`). When HA core is upgraded, this
+test passing means the integration still:
+
+1. Imports cleanly under the new HA's Python.
+2. Lets HA construct a config entry with our domain and platform list.
+3. Successfully enters `async_setup_entry`.
+4. Reaches `BromicHub.async_connect()`.
+5. Translates the connect failure into `ConfigEntryNotReady`, leaving the
+   entry in `ConfigEntryState.SETUP_RETRY`.
+
+If any of those steps regresses under a new HA, the assertion below fails
+with a different state name and surfaces the regression before merge.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from homeassistant.config_entries import ConfigEntryState
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bromic_smart_heat_link.const import (
+    CONF_SERIAL_PORT,
+    DOMAIN,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+@pytest.mark.asyncio
+async def test_setup_fails_predictably_without_hardware(
+    hass: HomeAssistant,
+    tmp_path,
+) -> None:
+    """
+    Set up the integration with a bogus serial port; expect SETUP_RETRY.
+
+    The integration's `async_setup_entry` wraps any `BromicHub.async_connect()`
+    failure in `ConfigEntryNotReady`, which HA renders as
+    `ConfigEntryState.SETUP_RETRY`. Pointing at a non-existent device path
+    under pytest's per-test tmp_path is the simplest way to provoke that
+    failure in CI without mocking.
+    """
+    bogus_port = str(tmp_path / "bromic-nonexistent-port")
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SERIAL_PORT: bogus_port},
+        title="Bromic Smoke Test",
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state == ConfigEntryState.SETUP_RETRY, (
+        f"Expected entry to be in SETUP_RETRY after a failed serial connect, "
+        f"but state is {entry.state.name}. This indicates the integration is "
+        f"no longer translating BromicHub.async_connect() failures into "
+        f"ConfigEntryNotReady, or it crashed before reaching that path."
+    )


### PR DESCRIPTION
## Summary
Adds a single `pytest-homeassistant-custom-component` smoke test that loads the integration with a non-existent serial port and asserts the config entry ends in `ConfigEntryState.SETUP_RETRY` — the documented failure mode when the Bromic bridge isn't reachable.

## Why this shape of smoke test
CI has no real serial hardware, so success-path testing would require mocking the entire serial stack — high effort, brittle, and doesn't actually prove the integration boots. Asserting the *predictable failure path* exercises:

- Python imports under the pinned HA's interpreter
- `async_setup_entry` entry
- `BromicHub.__init__` construction
- `BromicHub.async_connect()` reaching the serial layer
- The `ConfigEntryNotReady` translation in `__init__.py`

…all in ~30 lines without mocking. If a future HA bump regresses any of those, the entry state will be something other than `SETUP_RETRY` and the assertion's failure message names the difference.

## What's added
- `tests/__init__.py`, `tests/conftest.py`, `tests/test_smoke.py`
- `pytest.ini` (`asyncio_mode = auto`, `asyncio_default_fixture_loop_scope = function`)
- `requirements.txt`: `pytest-homeassistant-custom-component==0.13.214` (the helper paired with `homeassistant==2025.2.4` — established by querying PyPI for the exact lockstep version)
- `.github/workflows/test.yml` mirrors lockly's `tests.yml` shape (Python 3.13, no extra steps)
- `.ruff.toml` gains `[lint.per-file-ignores]` for `tests/**` — same set used in triad-ams / lockly / control4-dimmers

## Test plan
- Locally inside the bromic devcontainer: `pytest tests/ -v` passes.
- After merge, the new `Pytest` workflow runs in CI and goes green.

## Follow-up
Once this lands, the **bromic HA upgrade** (`homeassistant==2025.2.4 → 2026.5.x`) becomes safe to attempt: the smoke test re-running green on the new HA pin is the go/no-go signal. That's a separate PR.