### PR TITLE
chore(deps): upgrade to Home Assistant 2026.4.4 + Python 3.14

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "bharat/homeassistant-bromic-smart-heat-link",
-  "image": "mcr.microsoft.com/devcontainers/python:3.13",
+  "image": "mcr.microsoft.com/devcontainers/python:3.14",
   "postCreateCommand": "scripts/setup",
   "forwardPorts": [
     8123

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
 
       - name: Install requirements

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
 
       - name: Install requirements

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,6 +1,6 @@
 # The contents of this file is based on https://github.com/home-assistant/core/blob/dev/pyproject.toml
 
-target-version = "py313"
+target-version = "py314"
 
 [lint]
 select = [

--- a/custom_components/bromic_smart_heat_link/protocol.py
+++ b/custom_components/bromic_smart_heat_link/protocol.py
@@ -271,5 +271,5 @@ class BromicProtocol:
                 id_location=id_location, button_code=button_code, raw_bytes=data
             )
 
-        except (ValueError, IndexError):
+        except ValueError, IndexError:
             return None

--- a/renovate.json
+++ b/renovate.json
@@ -27,11 +27,6 @@
       "description": "homeassistant is upgraded in lockstep with pytest-homeassistant-custom-component (see AGENTS.md fleet policy). Let helper bumps drive the HA upgrade rather than bumping homeassistant directly."
     },
     {
-      "matchDepNames": ["python", "mcr.microsoft.com/devcontainers/python"],
-      "enabled": false,
-      "description": "Python upgrades blocked until bromic's HA pin (currently homeassistant==2025.2.4) is upgraded. The stale HA pulls in home-assistant-bluetooth==1.13.0 which has no Python 3.14 wheels, so any Python 3.14 bump fails pip resolution at CI time. Re-enable (delete this rule) once requirements.txt's homeassistant pin is on a release with Python 3.14 support."
-    },
-    {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "platformAutomerge": true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 colorlog==6.10.1
-homeassistant==2025.2.4
+homeassistant==2026.4.4
 pip>=26.1.1
 ruff==0.15.12
 pre_commit==4.6.0
 serial==0.0.97
-pytest-homeassistant-custom-component==0.13.214
+pytest-homeassistant-custom-component==0.13.325

--- a/scripts/customize.py
+++ b/scripts/customize.py
@@ -36,7 +36,7 @@ def read_origin_from_git_config(repo_root: Path) -> str | None:
         parser = configparser.ConfigParser()
         try:
             parser.read(config_path)
-        except (OSError, configparser.Error):
+        except OSError, configparser.Error:
             return None
         for section in parser.sections():
             if section.strip() == 'remote "origin"' and parser.has_option(
@@ -169,7 +169,7 @@ def replace_text_in_file(path: Path, replacements: tuple[tuple[str, str], ...]) 
     """Replace simple string pairs in a text file; return True if changed."""
     try:
         text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
+    except OSError, UnicodeDecodeError:
         return False
     original = text
     for old, new in replacements:
@@ -189,7 +189,7 @@ def update_manifest(manifest_path: Path, domain: str, display_name: str) -> None
         return
     try:
         data = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+    except OSError, UnicodeDecodeError, json.JSONDecodeError:
         return
     changed = False
     if data.get("domain") != domain:
@@ -215,7 +215,7 @@ def ensure_cursor_editor_in_devcontainer(repo_root: Path) -> None:
         return
     try:
         cfg = json.loads(devcontainer.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+    except OSError, UnicodeDecodeError, json.JSONDecodeError:
         return
     remote_env = cfg.get("remoteEnv", {})
     if remote_env.get("GIT_EDITOR") != "cursor":
@@ -238,7 +238,7 @@ def update_vscode_extensions_in_devcontainer(
         return
     try:
         cfg = json.loads(devcontainer.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+    except OSError, UnicodeDecodeError, json.JSONDecodeError:
         return
     customizations = cfg.setdefault("customizations", {})
     vscode = customizations.setdefault("vscode", {})
@@ -273,7 +273,7 @@ def ensure_line_in_file(path: Path, line: str) -> bool:
     """Append `line` to file if not already present; returns True if changed."""
     try:
         text = path.read_text(encoding="utf-8") if path.exists() else ""
-    except (OSError, UnicodeDecodeError):
+    except OSError, UnicodeDecodeError:
         return False
     if line in text:
         return False
@@ -297,7 +297,7 @@ def ensure_precommit_requirement(req_path: Path, version_pin: str = "3.5.0") -> 
             if req_path.exists()
             else []
         )
-    except (OSError, UnicodeDecodeError):
+    except OSError, UnicodeDecodeError:
         return False
     pin_line = f"pre_commit=={version_pin}"
     changed = False
@@ -335,7 +335,7 @@ def ensure_dod_in_devcontainer(repo_root: Path) -> bool:
         return False
     try:
         cfg = json.loads(devcontainer.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+    except OSError, UnicodeDecodeError, json.JSONDecodeError:
         return False
 
     changed = False
@@ -398,7 +398,7 @@ def rename_with_git_mv(old_path: Path, new_path: Path, repo_root: Path) -> bool:
                 cwd=str(repo_root),
                 check=True,
             )
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except subprocess.CalledProcessError, FileNotFoundError:
             shutil.move(str(old_path), str(new_path))
         else:
             return True

--- a/scripts/serial_send.py
+++ b/scripts/serial_send.py
@@ -65,7 +65,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.raw:
         try:
             frame = binascii.unhexlify(args.raw.replace(" ", ""))
-        except (binascii.Error, ValueError):
+        except binascii.Error, ValueError:
             sys.stderr.write("Invalid --raw hex string\n")
             return 2
     else:


### PR DESCRIPTION
## Summary
Bromic was 15 months behind the fleet (`homeassistant==2025.2.4` from Feb 2025). Catching up to **HA 2026.4.4** — the latest release aged ≥14 days per the supply-chain rule — and bumping Python to 3.14 (required by HA 2026.3+). The newly-added **smoke test from [#68](https://github.com/bharat/homeassistant-bromic-smart-heat-link/pull/68)** is the go/no-go: it asserts `ConfigEntryState.SETUP_RETRY` on the new HA, proving the integration still loads through `async_setup_entry` → `BromicHub.async_connect()` → `ConfigEntryNotReady` cleanly.

Local verification (rebuilt devcontainer on Python 3.14, installed new deps, ran pytest):

```
tests/test_smoke.py::test_setup_fails_predictably_without_hardware PASSED
```

## What's in
- `requirements.txt`: `homeassistant 2025.2.4 → 2026.4.4`
- `requirements.txt`: `pytest-homeassistant-custom-component 0.13.214 → 0.13.325` (the helper paired with HA 2026.4.4)
- `.devcontainer/devcontainer.json`: `python:3.13 → python:3.14`
- `.github/workflows/lint.yml`: `python-version 3.13 → 3.14`
- `.github/workflows/test.yml`: `python-version 3.13 → 3.14`
- `.ruff.toml`: `target-version py313 → py314`
- `renovate.json`: drop the temporary python-block `packageRules` entry (added in [#67](https://github.com/bharat/homeassistant-bromic-smart-heat-link/pull/67) to stop Renovate from re-proposing the bump while HA was stale)
- 3 source files reformatted by `ruff format` under the new py314 target (mechanical, no logic changes): `custom_components/.../protocol.py`, `scripts/customize.py`, `scripts/serial_send.py`

## Why 2026.4.4, not 2026.5.x
The fleet's 14-day supply-chain aging rule. HA `2026.5.0` and `2026.5.1` were published 2026-05-08 and 2026-05-09 (3–5 days old at PR time). HA `2026.4.4` was published 2026-04-24 (19 days old, passes the gate). Per the rule: pin to the newest aged version. Renovate will catch us up to 2026.5.x via a separate PR once those versions clear the gate.

## After merge
- The python-block `packageRule` is gone, so Renovate will start tracking python again. Next bump it'd propose is python `3.14.something-newer` if available.
- The aged-out `pin dependencies` PR (#66) should close itself on Renovate's next scan now that the renovate.json no longer has the block. If it doesn't, I'll close it.

## Test plan
- Existing CI (Hassfest/HACS/Brand) + new Pytest workflow runs on the bumped Python 3.14. All should be green.