### PR TITLE
test: add comprehensive unit-test suite for bromic integration

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -26,14 +26,25 @@ max-complexity = 25
 
 [lint.per-file-ignores]
 # Tests use asserts, magic numbers, private internals, and pytest fixture
-# injection that violates the global ANN/ARG rules in benign ways.
+# injection that violates the global ANN/ARG/D rules in benign ways.
 "tests/**" = [
     "S101",     # assert statements
     "PLR2004",  # magic value used in comparison
     "SLF001",   # private member accessed
     "ANN001",   # missing-type-function-argument (pytest fixtures)
     "ANN201",   # missing-return-type-undocumented-public-function
+    "ANN202",   # missing-return-type-private-function
     "ARG001",   # unused-function-argument (pytest fixture injection)
     "ARG002",   # unused-method-argument
+    "E501",     # line-too-long (test docstrings can be slightly verbose)
+    "D101",     # undocumented-public-class
+    "D102",     # undocumented-public-method
+    "D103",     # undocumented-public-function
     "D213",     # multi-line-docstring-summary-second-line (style)
+    "EM101",    # raw-string-in-exception (test stub messages)
+    "FBT001",   # boolean-type-hint-positional-argument
+    "N802",     # invalid-function-name (test_… can violate)
+    "PLC0415",  # import-outside-top-level (deferred imports in tests)
+    "PT017",    # pytest-assert-in-except (when validating exception path)
+    "RUF002",   # ambiguous-unicode-character-docstring
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ pip>=26.1.1
 ruff==0.15.12
 pre_commit==4.6.0
 serial==0.0.97
+pyserial>=3.5
 pytest-homeassistant-custom-component==0.13.325

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,148 @@
+"""Tests for the user-facing config flow.
+
+Focused on the initial `async_step_user` and `async_step_manual_port`
+paths. The deep learning-wizard options flow is exercised end-to-end
+against real hardware and isn't unit-tested here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+from homeassistant import config_entries, data_entry_flow
+
+from custom_components.bromic_smart_heat_link.const import (
+    CONF_SERIAL_PORT,
+    DOMAIN,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+class TestUserStep:
+    """`async_step_user` shows a port-picker form and accepts a selection."""
+
+    async def test_initial_form_shown_when_ports_discovered(
+        self, hass: HomeAssistant
+    ) -> None:
+        # Mock port discovery so the form has options to render.
+        discovered = [
+            {"device": "/dev/ttyUSB0", "description": "USB UART"},
+            {"device": "/dev/ttyUSB1", "description": "Other UART"},
+        ]
+        with patch(
+            "custom_components.bromic_smart_heat_link.config_flow.BromicHub.discover_ports",
+            AsyncMock(return_value=discovered),
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_USER}
+            )
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"] == {}
+
+    async def test_successful_selection_creates_entry(
+        self, hass: HomeAssistant
+    ) -> None:
+        discovered = [{"device": "/dev/ttyUSB0", "description": "USB UART"}]
+
+        with (
+            patch(
+                "custom_components.bromic_smart_heat_link.config_flow.BromicHub.discover_ports",
+                AsyncMock(return_value=discovered),
+            ),
+            patch(
+                "custom_components.bromic_smart_heat_link.config_flow.BromicHub.async_connect",
+                AsyncMock(),
+            ),
+            patch(
+                "custom_components.bromic_smart_heat_link.config_flow.BromicHub.async_test_connection",
+                AsyncMock(return_value=True),
+            ),
+            patch(
+                "custom_components.bromic_smart_heat_link.config_flow.BromicHub.async_disconnect",
+                AsyncMock(),
+            ),
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_USER}
+            )
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_SERIAL_PORT: "/dev/ttyUSB0"},
+            )
+
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_SERIAL_PORT] == "/dev/ttyUSB0"
+        # New entries start with no controllers configured.
+        assert result["options"]["controllers"] == {}
+
+    async def test_failed_connection_shows_error(self, hass: HomeAssistant) -> None:
+        discovered = [{"device": "/dev/ttyUSB0", "description": "USB UART"}]
+
+        with (
+            patch(
+                "custom_components.bromic_smart_heat_link.config_flow.BromicHub.discover_ports",
+                AsyncMock(return_value=discovered),
+            ),
+            patch(
+                "custom_components.bromic_smart_heat_link.config_flow.BromicHub.async_connect",
+                AsyncMock(side_effect=RuntimeError("nope")),
+            ),
+            patch(
+                "custom_components.bromic_smart_heat_link.config_flow.BromicHub.async_disconnect",
+                AsyncMock(),
+            ),
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_USER}
+            )
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_SERIAL_PORT: "/dev/ttyUSB0"},
+            )
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["errors"] == {"base": "cannot_connect"}
+
+
+class TestManualPortStep:
+    """`async_step_manual_port` is reached when the user picks 'Other'."""
+
+    async def test_manual_port_accepts_input_and_creates_entry(
+        self, hass: HomeAssistant
+    ) -> None:
+        # Empty discovery → form falls through to manual schema directly.
+        with (
+            patch(
+                "custom_components.bromic_smart_heat_link.config_flow.BromicHub.discover_ports",
+                AsyncMock(return_value=[]),
+            ),
+            patch(
+                "custom_components.bromic_smart_heat_link.config_flow.BromicHub.async_connect",
+                AsyncMock(),
+            ),
+            patch(
+                "custom_components.bromic_smart_heat_link.config_flow.BromicHub.async_test_connection",
+                AsyncMock(return_value=True),
+            ),
+            patch(
+                "custom_components.bromic_smart_heat_link.config_flow.BromicHub.async_disconnect",
+                AsyncMock(),
+            ),
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_USER}
+            )
+            # The user step itself uses the manual schema when there's nothing
+            # discovered. Submit a port directly.
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={CONF_SERIAL_PORT: "/dev/ttyACM0"},
+            )
+
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_SERIAL_PORT] == "/dev/ttyACM0"

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,0 +1,160 @@
+"""Tests for protocol constants and the storage normalizer.
+
+The constants in `const.py` encode the wire-format contract with the
+Bromic bridge — getting them wrong would break every command silently or
+cause spurious checksum failures. These tests pin the values so any
+accidental edit lands a red CI.
+"""
+
+from __future__ import annotations
+
+from custom_components.bromic_smart_heat_link.const import (
+    ACK_RESPONSE,
+    BRIGHTNESS_LEVELS,
+    BUTTON_SEQUENCE_DIMMER,
+    COMMAND_BYTE,
+    COMMAND_TIMEOUT,
+    DIMMER_BUTTONS,
+    DOMAIN,
+    ERROR_CODES,
+    ERROR_COMMAND,
+    INTER_FRAME_DELAY,
+    MAX_BUTTON_CODE,
+    MAX_ID_LOCATION,
+    MAX_RETRIES,
+    MIN_ID_LOCATION,
+    OFF_BUTTON_CODE,
+    ONOFF_BUTTONS,
+    SERIAL_CONFIG,
+    normalize_controller_data,
+)
+
+
+def test_domain_string_unchanged() -> None:
+    # Renaming the domain breaks every existing config entry and entity ID.
+    assert DOMAIN == "bromic_smart_heat_link"
+
+
+def test_command_byte_is_ascii_T() -> None:
+    # The bridge protocol opens every frame with 'T' (0x54).
+    assert COMMAND_BYTE == 0x54
+    assert ord("T") == COMMAND_BYTE
+
+
+def test_error_command_is_ascii_E() -> None:
+    # The bridge marks error responses with 'E' (0x45) as the first byte.
+    assert ERROR_COMMAND == 0x45
+    assert ord("E") == ERROR_COMMAND
+
+
+def test_ack_response_shape() -> None:
+    # Bromic documented ACK: 'T' + 0x06 + 'Z'.
+    assert bytes([0x54, 0x06, 0x5A]) == ACK_RESPONSE
+    assert len(ACK_RESPONSE) == 3
+
+
+def test_serial_config_matches_vendor_spec() -> None:
+    # 19200 baud 8N1 — the published Bromic bridge spec.
+    assert SERIAL_CONFIG["baudrate"] == 19200
+    assert SERIAL_CONFIG["bytesize"] == 8
+    assert SERIAL_CONFIG["parity"] == "N"
+    assert SERIAL_CONFIG["stopbits"] == 1
+    # No hardware/software flow control.
+    assert SERIAL_CONFIG["xonxoff"] is False
+    assert SERIAL_CONFIG["rtscts"] is False
+    assert SERIAL_CONFIG["dsrdtr"] is False
+
+
+def test_id_range() -> None:
+    assert MIN_ID_LOCATION == 1
+    assert MAX_ID_LOCATION == 50
+
+
+def test_safety_retry_bound() -> None:
+    # Safety-critical: don't allow unbounded retries on outdoor heater commands.
+    # If MAX_RETRIES grows without bharat's review, that's a regression.
+    assert MAX_RETRIES == 3
+    assert INTER_FRAME_DELAY == 0.1
+    assert COMMAND_TIMEOUT == 1.5
+
+
+def test_off_button_code() -> None:
+    assert OFF_BUTTON_CODE == 8
+    assert OFF_BUTTON_CODE == MAX_BUTTON_CODE
+
+
+def test_onoff_buttons_have_on_and_off() -> None:
+    assert 1 in ONOFF_BUTTONS
+    assert 2 in ONOFF_BUTTONS
+    assert ONOFF_BUTTONS[1]["function"] == "turn_on"
+    assert ONOFF_BUTTONS[2]["function"] == "turn_off"
+
+
+def test_dimmer_buttons_have_4_levels_plus_off() -> None:
+    assert set(DIMMER_BUTTONS) == {1, 2, 3, 4, OFF_BUTTON_CODE}
+    # Higher button number = lower power level (1=100%, 2=75%, 3=50%, 4=25%).
+    assert DIMMER_BUTTONS[1]["level"] == 100
+    assert DIMMER_BUTTONS[2]["level"] == 75
+    assert DIMMER_BUTTONS[3]["level"] == 50
+    assert DIMMER_BUTTONS[4]["level"] == 25
+
+
+def test_brightness_levels_discrete_mapping() -> None:
+    # HA 0-255 brightness scale → 5 discrete bridge levels.
+    assert set(BRIGHTNESS_LEVELS) == {0, 64, 128, 191, 255}
+    assert BRIGHTNESS_LEVELS[0]["button"] == OFF_BUTTON_CODE
+    assert BRIGHTNESS_LEVELS[64]["button"] == 4  # 25%
+    assert BRIGHTNESS_LEVELS[128]["button"] == 3  # 50%
+    assert BRIGHTNESS_LEVELS[191]["button"] == 2  # 75%
+    assert BRIGHTNESS_LEVELS[255]["button"] == 1  # 100%
+
+
+def test_learning_button_sequence_dimmer() -> None:
+    # The learning UI walks the user through buttons in this order. Off last.
+    assert BUTTON_SEQUENCE_DIMMER == [1, 2, 3, 4, OFF_BUTTON_CODE]
+
+
+def test_error_codes_cover_vendor_documented_set() -> None:
+    # Every documented error code should be present; arbitrary new codes
+    # would map to "Unknown error code: XX" in decode_response.
+    expected = {
+        0x00,  # Framing error
+        0x01,  # Checksum error
+        0x02,  # Wrong command error
+        0x03,  # ID = 0 error
+        0x04,  # ID > 2000 error
+        0x05,  # Number of code to read/delete = 0 error
+        0x06,  # Number of code to read > 16 or >128 error
+        0x07,  # Number of code to read/delete > 2000 (out of range) error
+        0x08,  # Serial code already stored error
+        0x09,  # ID < 201 error
+        0x10,  # Empty location transmission attempt error
+        0x11,  # Value out of valid codes range memorization attempt error
+    }
+    assert set(ERROR_CODES) == expected
+
+
+class TestNormalizeControllerData:
+    """Storage-loaded controller data has string keys; we coerce to ints."""
+
+    def test_string_keys_become_ints(self) -> None:
+        result = normalize_controller_data(
+            {"learned_buttons": {"1": True, "2": False, "8": True}}
+        )
+        assert result["learned_buttons"] == {1: True, 2: False, 8: True}
+
+    def test_int_keys_pass_through(self) -> None:
+        result = normalize_controller_data({"learned_buttons": {1: True, 2: False}})
+        assert result["learned_buttons"] == {1: True, 2: False}
+
+    def test_missing_learned_buttons_returns_empty_dict(self) -> None:
+        result = normalize_controller_data({"controller_type": "onoff"})
+        assert result["learned_buttons"] == {}
+        # Other keys are preserved.
+        assert result["controller_type"] == "onoff"
+
+    def test_non_castable_keys_swallowed(self) -> None:
+        # The function uses `contextlib.suppress(Exception)` — if a key can't
+        # be int-cast, it returns the original dict rather than raising.
+        result = normalize_controller_data({"learned_buttons": {"not-a-number": True}})
+        assert "learned_buttons" in result

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,176 @@
+"""Tests for the diagnostics payload.
+
+Critical assertions:
+- The serial port is redacted (it can contain identifying USB IDs).
+- Hub stats are surfaced.
+- Controller metadata is summarized (type + learned button count).
+
+**Known production bug** (discovered while writing these tests, not fixed
+here per the tests-only constraint): `diagnostics.py:43` uses
+`hass.helpers.entity_registry.async_get(hass)` — the deprecated/removed
+HA helpers API. Under HA 2026.4.4, this raises `AttributeError`. These
+tests mock `hass.helpers` to exercise the rest of the payload shape; the
+real diagnostics endpoint would crash in production. Tracked separately
+for a follow-up fix.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bromic_smart_heat_link.const import (
+    CONF_CONTROLLER_TYPE,
+    CONF_CONTROLLERS,
+    CONF_LEARNED_BUTTONS,
+    CONF_SERIAL_PORT,
+    CONTROLLER_TYPE_DIMMER,
+    CONTROLLER_TYPE_ONOFF,
+    DOMAIN,
+)
+from custom_components.bromic_smart_heat_link.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+async def test_serial_port_redacted_in_data(hass: HomeAssistant) -> None:
+    """`async_redact_data` should hide CONF_SERIAL_PORT in entry.data."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SERIAL_PORT: "/dev/ttyUSB0"},
+        options={CONF_CONTROLLERS: {}},
+        title="Test",
+    )
+    entry.add_to_hass(hass)
+
+    hub = MagicMock()
+    hub.connected = True
+    hub.port = "/dev/ttyUSB0"
+    hub.stats = {"commands_sent": 5}
+    hass.data[DOMAIN] = {entry.entry_id: {"hub": hub}}
+
+    # Mock the deprecated hass.helpers.entity_registry path that diagnostics.py
+    # still calls. See module-level docstring; this is a known production bug.
+    fake_registry = MagicMock()
+    fake_registry.entities.values.return_value = []
+    hass.helpers = MagicMock()
+    hass.helpers.entity_registry.async_get.return_value = fake_registry
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+    # Redacted form is **REDACTED** (HA's standard sentinel).
+    assert diag["config_entry"]["data"][CONF_SERIAL_PORT] != "/dev/ttyUSB0"
+
+
+async def test_hub_port_redacted_in_hub_section(hass: HomeAssistant) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SERIAL_PORT: "/dev/ttyUSB0"},
+        options={},
+        title="Test",
+    )
+    entry.add_to_hass(hass)
+
+    hub = MagicMock()
+    hub.connected = True
+    hub.port = "/dev/ttyUSB0"
+    hub.stats = {"commands_sent": 0}
+    hass.data[DOMAIN] = {entry.entry_id: {"hub": hub}}
+
+    # Mock the deprecated hass.helpers.entity_registry path that diagnostics.py
+    # still calls. See module-level docstring; this is a known production bug.
+    fake_registry = MagicMock()
+    fake_registry.entities.values.return_value = []
+    hass.helpers = MagicMock()
+    hass.helpers.entity_registry.async_get.return_value = fake_registry
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+    assert diag["hub"]["port"] != "/dev/ttyUSB0"
+
+
+async def test_hub_stats_surface(hass: HomeAssistant) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SERIAL_PORT: "/dev/ttyUSB0"},
+        options={},
+        title="Test",
+    )
+    entry.add_to_hass(hass)
+
+    hub = MagicMock()
+    hub.connected = True
+    hub.port = "/dev/ttyUSB0"
+    hub.stats = {
+        "commands_sent": 7,
+        "commands_successful": 5,
+        "commands_failed": 2,
+    }
+    hass.data[DOMAIN] = {entry.entry_id: {"hub": hub}}
+
+    # Mock the deprecated hass.helpers.entity_registry path that diagnostics.py
+    # still calls. See module-level docstring; this is a known production bug.
+    fake_registry = MagicMock()
+    fake_registry.entities.values.return_value = []
+    hass.helpers = MagicMock()
+    hass.helpers.entity_registry.async_get.return_value = fake_registry
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+    assert diag["hub"]["connected"] is True
+    assert diag["hub"]["statistics"]["commands_sent"] == 7
+    assert diag["hub"]["statistics"]["commands_successful"] == 5
+    assert diag["hub"]["statistics"]["commands_failed"] == 2
+
+
+async def test_controllers_summary(hass: HomeAssistant) -> None:
+    """The 'controllers' section summarizes type + learned button count per ID."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SERIAL_PORT: "/dev/ttyUSB0"},
+        options={
+            CONF_CONTROLLERS: {
+                "1": {
+                    CONF_CONTROLLER_TYPE: CONTROLLER_TYPE_ONOFF,
+                    CONF_LEARNED_BUTTONS: {1: True, 2: True},
+                },
+                "5": {
+                    CONF_CONTROLLER_TYPE: CONTROLLER_TYPE_DIMMER,
+                    CONF_LEARNED_BUTTONS: {
+                        1: True,
+                        2: True,
+                        3: False,
+                        4: True,
+                        8: True,
+                    },
+                },
+            },
+        },
+        title="Test",
+    )
+    entry.add_to_hass(hass)
+
+    hub = MagicMock()
+    hub.connected = True
+    hub.port = "/dev/ttyUSB0"
+    hub.stats = {}
+    hass.data[DOMAIN] = {entry.entry_id: {"hub": hub}}
+
+    # Mock the deprecated hass.helpers.entity_registry path that diagnostics.py
+    # still calls. See module-level docstring; this is a known production bug.
+    fake_registry = MagicMock()
+    fake_registry.entities.values.return_value = []
+    hass.helpers = MagicMock()
+    hass.helpers.entity_registry.async_get.return_value = fake_registry
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert "1" in diag["controllers"]
+    assert diag["controllers"]["1"]["type"] == CONTROLLER_TYPE_ONOFF
+    assert diag["controllers"]["1"]["learned_button_count"] == 2  # both True
+
+    assert diag["controllers"]["5"]["type"] == CONTROLLER_TYPE_DIMMER
+    # 4 of 5 buttons learned (one is False).
+    assert diag["controllers"]["5"]["learned_button_count"] == 4

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,0 +1,173 @@
+"""Tests for `BromicEntity` — the base class shared by switch and light.
+
+Covers: identifier generation, device_info, stats-attribute reporting,
+the success/failure command paths, and the connection-state callback
+that toggles `_attr_available`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.bromic_smart_heat_link.const import (
+    ATTR_COMMAND_COUNT,
+    ATTR_ERROR_COUNT,
+    ATTR_ID_LOCATION,
+    ATTR_LAST_COMMAND_TIME,
+    DOMAIN,
+)
+from custom_components.bromic_smart_heat_link.entity import BromicEntity
+from custom_components.bromic_smart_heat_link.protocol import BromicResponse
+
+
+def _make_hub(
+    port: str = "/dev/ttyUSB0", *, last_success: float = 12345.0
+) -> MagicMock:
+    """Mock just enough of `BromicHub` for `BromicEntity` to use."""
+    hub = MagicMock(name="hub")
+    hub.port = port
+    hub.stats = {"last_success": last_success}
+    hub.async_send_command = AsyncMock()
+    return hub
+
+
+def _make_entity(hub: MagicMock, id_location: int = 5) -> BromicEntity:
+    return BromicEntity(
+        hub=hub,
+        id_location=id_location,
+        controller_type="onoff",
+        entity_type="switch",
+    )
+
+
+class TestIdentifiers:
+    """Identifier construction is deterministic and port-derived."""
+
+    def test_unique_id_includes_domain_port_id_and_entity_type(self) -> None:
+        hub = _make_hub(port="/dev/ttyUSB0")
+        entity = _make_entity(hub, id_location=7)
+        assert entity.unique_id == f"{DOMAIN}__dev_ttyUSB0_7_switch"
+
+    def test_slashes_and_colons_in_port_become_underscores(self) -> None:
+        # The port identifier is munged so it can be used in device.identifiers
+        # without quoting; / and : are the two characters that get replaced.
+        hub = _make_hub(port="socket://192.168.1.10:7777")
+        entity = _make_entity(hub, id_location=1)
+        assert "/" not in entity.unique_id
+        assert ":" not in entity.unique_id
+
+    def test_device_info_uses_id_in_identifier(self) -> None:
+        hub = _make_hub(port="/dev/ttyUSB0")
+        entity = _make_entity(hub, id_location=12)
+        identifiers = entity.device_info["identifiers"]
+        assert (DOMAIN, "_dev_ttyUSB0_12") in identifiers
+
+    def test_device_info_via_device_links_to_bridge(self) -> None:
+        hub = _make_hub(port="/dev/ttyUSB0")
+        entity = _make_entity(hub, id_location=1)
+        # via_device points at the bridge for this serial port (without ID suffix).
+        assert entity.device_info["via_device"] == (DOMAIN, "_dev_ttyUSB0")
+
+    def test_device_info_name_includes_id(self) -> None:
+        hub = _make_hub()
+        entity = _make_entity(hub, id_location=3)
+        assert entity.device_info["name"] == "Bromic ID3"
+
+    def test_has_entity_name_true_with_no_entity_name(self) -> None:
+        # The base sets `_attr_has_entity_name=True` and `_attr_name=None` so
+        # the object_id derives solely from the device name.
+        hub = _make_hub()
+        entity = _make_entity(hub)
+        assert entity.has_entity_name is True
+        assert entity.name is None
+
+
+class TestExtraStateAttributes:
+    """The stats panel exposes only the non-zero / non-empty fields."""
+
+    def test_only_id_location_when_no_activity(self) -> None:
+        hub = _make_hub()
+        entity = _make_entity(hub, id_location=4)
+        attrs = entity.extra_state_attributes
+        assert attrs == {ATTR_ID_LOCATION: 4}
+
+    def test_command_count_appears_after_successful_command(self) -> None:
+        hub = _make_hub(last_success=42.0)
+        hub.async_send_command.return_value = BromicResponse(
+            success=True, error_code=None, message="ok", raw_bytes=b""
+        )
+        entity = _make_entity(hub, id_location=4)
+
+        # Drive a successful command through the entity.
+        import asyncio
+
+        result = asyncio.get_event_loop().run_until_complete(
+            entity.async_send_command(1)
+        )
+        assert result is True
+
+        attrs = entity.extra_state_attributes
+        assert attrs[ATTR_COMMAND_COUNT] == 1
+        assert attrs[ATTR_LAST_COMMAND_TIME] == 42.0
+        assert ATTR_ERROR_COUNT not in attrs  # error_count == 0, hidden
+
+
+class TestAsyncSendCommand:
+    """The base entity owns success/failure bookkeeping and availability flipping."""
+
+    async def test_success_returns_true_marks_available(self) -> None:
+        hub = _make_hub()
+        hub.async_send_command.return_value = BromicResponse(
+            success=True, error_code=None, message="ok", raw_bytes=b""
+        )
+        entity = _make_entity(hub)
+        # Force an initial "unavailable" to verify success flips back.
+        entity._attr_available = False
+
+        ok = await entity.async_send_command(2)
+        assert ok is True
+        assert entity.available is True
+        assert entity.extra_state_attributes[ATTR_COMMAND_COUNT] == 1
+
+    async def test_failed_response_returns_false_keeps_available(self) -> None:
+        # A protocol-level failure (e.g. error response from the bridge)
+        # does NOT mark the entity unavailable — only thrown exceptions do.
+        # That matches the integration's documented retry semantics: failures
+        # are noted in stats but the entity stays online.
+        hub = _make_hub()
+        hub.async_send_command.return_value = BromicResponse(
+            success=False, error_code=0x02, message="Wrong command", raw_bytes=b""
+        )
+        entity = _make_entity(hub)
+
+        ok = await entity.async_send_command(2)
+        assert ok is False
+        assert entity.available is True  # not flipped to False
+        # error_count incremented; command_count NOT incremented (only on success path).
+        attrs = entity.extra_state_attributes
+        assert attrs.get(ATTR_ERROR_COUNT) == 1
+
+    async def test_exception_returns_false_marks_unavailable(self) -> None:
+        # A thrown exception flips _attr_available=False (the connection is
+        # suspect). This is the "device disappeared" case.
+        hub = _make_hub()
+        hub.async_send_command.side_effect = RuntimeError("connection lost")
+        entity = _make_entity(hub)
+
+        ok = await entity.async_send_command(2)
+        assert ok is False
+        assert entity.available is False
+        assert entity.extra_state_attributes.get(ATTR_ERROR_COUNT) == 1
+
+
+class TestConnectionCallback:
+    """`_on_connection_state_changed` toggles `_attr_available`."""
+
+    def test_callback_toggles_availability(self) -> None:
+        hub = _make_hub()
+        entity = _make_entity(hub)
+        # hass not set on the entity → async_write_ha_state should be guarded.
+        entity._on_connection_state_changed(connected=False)
+        assert entity.available is False
+        entity._on_connection_state_changed(connected=True)
+        assert entity.available is True

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,86 @@
+"""Tests for the Bromic exception hierarchy.
+
+Verifies that each integration-specific exception inherits the expected
+parent class so HA's `HomeAssistantError`-aware handling (e.g. user-facing
+notifications) treats them correctly, and that `BromicCommandError` stores
+the protocol-level error code.
+"""
+
+from __future__ import annotations
+
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.bromic_smart_heat_link.exceptions import (
+    BromicChecksumError,
+    BromicCommandError,
+    BromicConfigurationError,
+    BromicConnectionError,
+    BromicDeviceNotFoundError,
+    BromicError,
+    BromicInvalidResponseError,
+    BromicLearningError,
+    BromicProtocolError,
+    BromicSerialError,
+    BromicTimeoutError,
+)
+
+
+class TestExceptionHierarchy:
+    """Each exception is a HomeAssistantError so HA treats it consistently."""
+
+    def test_base_inherits_homeassistanterror(self) -> None:
+        assert issubclass(BromicError, HomeAssistantError)
+
+    def test_connection_inherits_base(self) -> None:
+        assert issubclass(BromicConnectionError, BromicError)
+
+    def test_timeout_inherits_base(self) -> None:
+        assert issubclass(BromicTimeoutError, BromicError)
+
+    def test_protocol_inherits_base(self) -> None:
+        assert issubclass(BromicProtocolError, BromicError)
+
+    def test_checksum_inherits_protocol(self) -> None:
+        assert issubclass(BromicChecksumError, BromicProtocolError)
+
+    def test_invalid_response_inherits_protocol(self) -> None:
+        assert issubclass(BromicInvalidResponseError, BromicProtocolError)
+
+    def test_serial_inherits_connection(self) -> None:
+        # Serial errors are a flavor of connection error — HA can treat them
+        # the same way at the entry-setup layer.
+        assert issubclass(BromicSerialError, BromicConnectionError)
+
+    def test_device_not_found_inherits_connection(self) -> None:
+        assert issubclass(BromicDeviceNotFoundError, BromicConnectionError)
+
+    def test_command_inherits_base(self) -> None:
+        assert issubclass(BromicCommandError, BromicError)
+
+    def test_learning_inherits_base(self) -> None:
+        assert issubclass(BromicLearningError, BromicError)
+
+    def test_configuration_inherits_base(self) -> None:
+        assert issubclass(BromicConfigurationError, BromicError)
+
+
+class TestCommandErrorCarriesCode:
+    """`BromicCommandError` is the only one with a custom __init__ — the device's error code."""
+
+    def test_with_error_code(self) -> None:
+        err = BromicCommandError("Wrong command", error_code=0x02)
+        assert str(err) == "Wrong command"
+        assert err.error_code == 0x02
+
+    def test_without_error_code_defaults_to_none(self) -> None:
+        err = BromicCommandError("Generic failure")
+        assert str(err) == "Generic failure"
+        assert err.error_code is None
+
+    def test_is_raisable_and_catchable_as_base(self) -> None:
+        # Critical: code that catches BromicError should catch BromicCommandError.
+        try:
+            raise BromicCommandError("test", error_code=0x05)
+        except BromicError as caught:
+            assert isinstance(caught, BromicCommandError)
+            assert caught.error_code == 0x05

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,0 +1,338 @@
+"""Tests for `BromicHub` — the serial I/O layer.
+
+CI has no real serial hardware, so every test here mocks `serial.Serial`.
+The goal is to pin down the hub's behavioral contract: connection lifecycle,
+retry policy, statistics tracking, the `ConfigEntryNotReady` path used by
+`async_setup_entry`, and the connection-state callback fan-out.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import serial as pyserial
+
+from custom_components.bromic_smart_heat_link.const import ACK_RESPONSE
+from custom_components.bromic_smart_heat_link.exceptions import (
+    BromicConnectionError,
+    BromicTimeoutError,
+)
+from custom_components.bromic_smart_heat_link.hub import BromicHub
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+def _make_fake_serial(*, response: bytes = ACK_RESPONSE) -> MagicMock:
+    """Build a MagicMock that quacks like a `serial.Serial` returning `response`.
+
+    The hub reads `in_waiting` and then calls `read(n)`. We arrange the mock so
+    that the first poll returns 0 (no data yet), then enough bytes for the
+    response, then 0 again.
+    """
+    fake = MagicMock(name="fake_serial.Serial")
+    fake.is_open = True
+
+    # Track read state across calls to in_waiting and read().
+    state = {"sent": False}
+
+    def _in_waiting() -> int:
+        if not state["sent"]:
+            return 0  # waiting for write to complete
+        return len(response)
+
+    type(fake).in_waiting = property(lambda _self: _in_waiting())
+
+    def _read(n: int = 1) -> bytes:
+        return response[:n]
+
+    fake.read.side_effect = _read
+
+    def _write(_data: bytes) -> int:
+        # Flip state.sent so the next in_waiting poll reports the response
+        # is available. The read loop polls in_waiting > 0 and then read()s.
+        state["sent"] = True
+        return len(_data)
+
+    fake.write.side_effect = _write
+    fake.flush.return_value = None
+    fake.close.return_value = None
+    return fake
+
+
+class TestInitialization:
+    """Hub starts in a clean disconnected state."""
+
+    def test_initial_state(self, hass: HomeAssistant) -> None:
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        assert hub.port == "/dev/ttyUSB0"
+        assert hub.connected is False
+
+    def test_stats_returns_copy(self, hass: HomeAssistant) -> None:
+        # The `stats` property must return a copy — callers shouldn't mutate live state.
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        snap = hub.stats
+        snap["commands_sent"] = 999
+        assert hub.stats["commands_sent"] == 0
+
+    def test_stats_initial_zero(self, hass: HomeAssistant) -> None:
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        s = hub.stats
+        assert s["commands_sent"] == 0
+        assert s["commands_successful"] == 0
+        assert s["commands_failed"] == 0
+        assert s["connection_errors"] == 0
+        assert s["last_error"] is None
+        assert s["last_success"] is None
+
+
+class TestConnectionCallbacks:
+    """Callbacks fire on `_notify_connection_state` and survive exceptions."""
+
+    def test_add_then_notify(self, hass: HomeAssistant) -> None:
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        seen: list[bool] = []
+        hub.add_connection_callback(seen.append)
+        hub._notify_connection_state(connected=True)
+        hub._notify_connection_state(connected=False)
+        assert seen == [True, False]
+
+    def test_remove_stops_notifications(self, hass: HomeAssistant) -> None:
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        seen: list[bool] = []
+        hub.add_connection_callback(seen.append)
+        hub.remove_connection_callback(seen.append)
+        hub._notify_connection_state(connected=True)
+        assert seen == []
+
+    def test_remove_callback_not_registered_is_noop(self, hass: HomeAssistant) -> None:
+        # The implementation guards on `if callback in self._connection_callbacks`,
+        # so removing one that was never added must not raise.
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        hub.remove_connection_callback(lambda _c: None)
+
+    def test_exception_in_callback_does_not_break_fanout(
+        self, hass: HomeAssistant
+    ) -> None:
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        seen: list[bool] = []
+
+        def bad(_c: bool) -> None:
+            msg = "callback boom"
+            raise RuntimeError(msg)
+
+        hub.add_connection_callback(bad)
+        hub.add_connection_callback(seen.append)
+        hub._notify_connection_state(connected=True)
+        # The second callback still ran despite the first one raising.
+        assert seen == [True]
+
+
+class TestAsyncConnect:
+    """`async_connect` opens the serial port and updates state / stats / callbacks."""
+
+    async def test_success_path(self, hass: HomeAssistant) -> None:
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        seen: list[bool] = []
+        hub.add_connection_callback(seen.append)
+
+        fake = _make_fake_serial()
+        with patch.object(pyserial, "Serial", return_value=fake) as ctor:
+            await hub.async_connect()
+
+        assert hub.connected is True
+        assert hub.stats["last_success"] is not None
+        assert seen == [True]
+        ctor.assert_called_once()
+
+    async def test_idempotent_when_already_connected(self, hass: HomeAssistant) -> None:
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        with patch.object(pyserial, "Serial", return_value=_make_fake_serial()):
+            await hub.async_connect()
+            # Second call short-circuits and doesn't even touch serial.Serial.
+            with patch.object(pyserial, "Serial") as ctor:
+                await hub.async_connect()
+                ctor.assert_not_called()
+        assert hub.connected is True
+
+    async def test_serial_failure_raises_bromic_connection_error(
+        self, hass: HomeAssistant
+    ) -> None:
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        seen: list[bool] = []
+        hub.add_connection_callback(seen.append)
+
+        with (
+            patch.object(
+                pyserial, "Serial", side_effect=pyserial.SerialException("nope")
+            ),
+            pytest.raises(BromicConnectionError),
+        ):
+            await hub.async_connect()
+
+        assert hub.connected is False
+        assert hub.stats["connection_errors"] == 1
+        assert hub.stats["last_error"] is not None
+        # The failure callback fired with connected=False.
+        assert seen == [False]
+
+
+class TestAsyncDisconnect:
+    """`async_disconnect` is a no-op when never connected; otherwise closes."""
+
+    async def test_disconnect_when_never_connected_is_noop(
+        self, hass: HomeAssistant
+    ) -> None:
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        # Should not raise.
+        await hub.async_disconnect()
+        assert hub.connected is False
+
+    async def test_disconnect_after_connect_closes_serial(
+        self, hass: HomeAssistant
+    ) -> None:
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        fake = _make_fake_serial()
+        seen: list[bool] = []
+        hub.add_connection_callback(seen.append)
+
+        with patch.object(pyserial, "Serial", return_value=fake):
+            await hub.async_connect()
+
+        await hub.async_disconnect()
+        assert hub.connected is False
+        fake.close.assert_called()
+        # Both transitions surfaced.
+        assert seen == [True, False]
+
+
+class TestAsyncSendCommand:
+    """Sending commands: success counts, failure-response counts, retries, and not-connected gate."""
+
+    async def test_not_connected_raises(self, hass: HomeAssistant) -> None:
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        with pytest.raises(BromicConnectionError):
+            await hub.async_send_command(1, 1)
+
+    async def test_success_increments_stats(self, hass: HomeAssistant) -> None:
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        with patch.object(
+            pyserial, "Serial", return_value=_make_fake_serial(response=ACK_RESPONSE)
+        ):
+            await hub.async_connect()
+
+        response = await hub.async_send_command(1, 1)
+        assert response.success is True
+        s = hub.stats
+        assert s["commands_sent"] == 1
+        assert s["commands_successful"] == 1
+        assert s["commands_failed"] == 0
+
+    async def test_error_response_increments_failed(self, hass: HomeAssistant) -> None:
+        # 'E' 0x02 0x00 = "Wrong command" error response shape.
+        from custom_components.bromic_smart_heat_link.const import ERROR_COMMAND
+
+        bad_response = bytes([ERROR_COMMAND, 0x02, 0x00])
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        with patch.object(
+            pyserial, "Serial", return_value=_make_fake_serial(response=bad_response)
+        ):
+            await hub.async_connect()
+
+        response = await hub.async_send_command(1, 1)
+        assert response.success is False
+        assert response.error_code == 0x02
+        s = hub.stats
+        # commands_sent is still incremented (we did send something).
+        assert s["commands_sent"] == 1
+        assert s["commands_failed"] == 1
+        assert s["commands_successful"] == 0
+
+    async def test_retries_then_raises_after_exhaustion(
+        self, hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Speed up: drop the exponential backoff to zero so the test doesn't wait.
+        async def _fast_sleep(_delay: float) -> None:
+            return None
+
+        monkeypatch.setattr(
+            "custom_components.bromic_smart_heat_link.hub.asyncio.sleep", _fast_sleep
+        )
+
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        with patch.object(pyserial, "Serial", return_value=_make_fake_serial()):
+            await hub.async_connect()
+
+        # Make the sync send path raise every time.
+        with (
+            patch.object(
+                hub, "_send_command_sync", side_effect=BromicTimeoutError("nope")
+            ),
+            pytest.raises(BromicTimeoutError),
+        ):
+            await hub.async_send_command(1, 1, retries=2)
+
+        # 3 attempts (initial + 2 retries) all failed.
+        assert hub.stats["commands_failed"] == 3
+
+    async def test_retry_succeeds_on_second_attempt(
+        self, hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def _fast_sleep(_delay: float) -> None:
+            return None
+
+        monkeypatch.setattr(
+            "custom_components.bromic_smart_heat_link.hub.asyncio.sleep", _fast_sleep
+        )
+
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        with patch.object(pyserial, "Serial", return_value=_make_fake_serial()):
+            await hub.async_connect()
+
+        from custom_components.bromic_smart_heat_link.protocol import BromicResponse
+
+        ok = BromicResponse(
+            success=True, error_code=None, message="ok", raw_bytes=ACK_RESPONSE
+        )
+        call_count = {"n": 0}
+
+        def fake_sync(_cmd):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                msg = "first attempt fails"
+                raise BromicTimeoutError(msg)
+            return ok
+
+        with patch.object(hub, "_send_command_sync", side_effect=fake_sync):
+            resp = await hub.async_send_command(1, 1, retries=2)
+
+        assert resp.success is True
+        assert call_count["n"] == 2
+        assert hub.stats["commands_failed"] == 1  # the first attempt
+        assert hub.stats["commands_successful"] == 1
+
+
+class TestAsyncTestConnection:
+    """`async_test_connection` returns True iff a no-op command succeeds."""
+
+    async def test_returns_false_when_not_connected(self, hass: HomeAssistant) -> None:
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        assert await hub.async_test_connection() is False
+
+    async def test_returns_false_when_command_raises(
+        self, hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def _fast_sleep(_delay: float) -> None:
+            return None
+
+        monkeypatch.setattr(
+            "custom_components.bromic_smart_heat_link.hub.asyncio.sleep", _fast_sleep
+        )
+        hub = BromicHub(hass, "/dev/ttyUSB0")
+        with patch.object(pyserial, "Serial", return_value=_make_fake_serial()):
+            await hub.async_connect()
+        async_send = AsyncMock(side_effect=BromicTimeoutError("nope"))
+        with patch.object(hub, "async_send_command", async_send):
+            assert await hub.async_test_connection() is False

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1,0 +1,183 @@
+"""Tests for `BromicLight` — the dimmer controller entity with discrete brightness levels.
+
+Covers: brightness-to-button mapping (HA's 0-255 → 5 discrete levels),
+the `_map_brightness_to_discrete` closest-match logic, turn_on / turn_off
+with state updates, and the case where the off button isn't learned.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode
+
+from custom_components.bromic_smart_heat_link.const import OFF_BUTTON_CODE
+from custom_components.bromic_smart_heat_link.light import (
+    DISCRETE_BRIGHTNESS_LEVELS,
+    BromicLight,
+)
+from custom_components.bromic_smart_heat_link.protocol import BromicResponse
+
+ALL_LEARNED = {1: True, 2: True, 3: True, 4: True, OFF_BUTTON_CODE: True}
+
+
+def _make_light(
+    *,
+    learned: dict[int, bool] | None = None,
+    send_result: BromicResponse | None = None,
+) -> tuple[BromicLight, MagicMock]:
+    hub = MagicMock(name="hub")
+    hub.port = "/dev/ttyUSB0"
+    hub.stats = {"last_success": 0.0}
+    if send_result is None:
+        send_result = BromicResponse(
+            success=True, error_code=None, message="ok", raw_bytes=b""
+        )
+    hub.async_send_command = AsyncMock(return_value=send_result)
+
+    light = BromicLight(
+        hub=hub,
+        id_location=7,
+        controller_type="dimmer",
+        learned_buttons=learned if learned is not None else ALL_LEARNED,
+    )
+    light.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
+    return light, hub
+
+
+class TestInitialState:
+    def test_starts_off_with_zero_brightness(self) -> None:
+        light, _ = _make_light()
+        assert light.is_on is False
+        assert light.brightness == 0
+
+    def test_color_mode_is_brightness_only(self) -> None:
+        light, _ = _make_light()
+        assert light.color_mode == ColorMode.BRIGHTNESS
+        assert light.supported_color_modes == {ColorMode.BRIGHTNESS}
+
+    def test_assumed_state(self) -> None:
+        light, _ = _make_light()
+        assert light.assumed_state is True
+
+    def test_available_brightness_levels_reflect_learned_buttons(self) -> None:
+        # If only 100% and Off are learned, only those should appear.
+        partial = {1: True, OFF_BUTTON_CODE: True, 2: False, 3: False, 4: False}
+        light, _ = _make_light(learned=partial)
+        attrs = light.extra_state_attributes
+        # The key strings are stringified brightness values.
+        levels = set(attrs["available_power_levels"])
+        assert levels == {"0", "255"}  # Off + 100%
+
+
+class TestBrightnessToButtonMapping:
+    """Brightness levels map to button codes per the documented LUT."""
+
+    def test_full_lut_when_all_buttons_learned(self) -> None:
+        light, _ = _make_light()
+        # 0/64/128/191/255 each maps to a button.
+        assert light._brightness_to_button == {
+            0: OFF_BUTTON_CODE,
+            64: 4,  # 25%
+            128: 3,  # 50%
+            191: 2,  # 75%
+            255: 1,  # 100%
+        }
+
+    def test_unlearned_buttons_dropped_from_map(self) -> None:
+        partial = {1: True, OFF_BUTTON_CODE: True}  # 100% and Off only
+        light, _ = _make_light(learned=partial)
+        assert set(light._brightness_to_button) == {0, 255}
+
+
+class TestMapBrightnessToDiscrete:
+    """`_map_brightness_to_discrete` picks the closest available level."""
+
+    def test_zero_maps_to_zero(self) -> None:
+        light, _ = _make_light()
+        assert light._map_brightness_to_discrete(0) == 0
+
+    def test_exact_levels_pass_through(self) -> None:
+        light, _ = _make_light()
+        for level in (64, 128, 191, 255):
+            assert light._map_brightness_to_discrete(level) == level
+
+    def test_in_between_picks_closest(self) -> None:
+        # 100 is between 64 and 128. Closest: 128 (distance 28 < 36).
+        light, _ = _make_light()
+        assert light._map_brightness_to_discrete(100) == 128
+        # 90 is closer to 64 (distance 26) than to 128 (distance 38).
+        assert light._map_brightness_to_discrete(90) == 64
+
+    def test_no_levels_available_returns_max(self) -> None:
+        # If nothing > 0 is learned, fallback is 255.
+        only_off = {OFF_BUTTON_CODE: True, 1: False, 2: False, 3: False, 4: False}
+        light, _ = _make_light(learned=only_off)
+        assert light._map_brightness_to_discrete(100) == 255
+
+
+class TestAsyncTurnOn:
+    async def test_default_brightness_full_power(self) -> None:
+        # No ATTR_BRIGHTNESS = full power → button 1.
+        light, hub = _make_light()
+        await light.async_turn_on()
+        hub.async_send_command.assert_awaited_once_with(7, 1)
+        assert light.is_on is True
+        assert light.brightness == 255
+
+    async def test_explicit_brightness_maps_to_correct_button(self) -> None:
+        light, hub = _make_light()
+        await light.async_turn_on(**{ATTR_BRIGHTNESS: 64})
+        # 64 → 25% → button 4.
+        hub.async_send_command.assert_awaited_once_with(7, 4)
+        assert light.brightness == 64
+
+    async def test_no_state_change_on_failed_response(self) -> None:
+        bad = BromicResponse(
+            success=False, error_code=0x02, message="Wrong command", raw_bytes=b""
+        )
+        light, _ = _make_light(send_result=bad)
+        await light.async_turn_on()
+        assert light.is_on is False
+        assert light.brightness == 0
+
+    async def test_unlearned_level_skips_send(self) -> None:
+        # Only 100% learned. Request for 64 (25%) should refuse silently.
+        partial = {1: True, OFF_BUTTON_CODE: True, 2: False, 3: False, 4: False}
+        light, hub = _make_light(learned=partial)
+        # Bypass closest-match by patching it to return an unlearned level.
+        light._map_brightness_to_discrete = lambda _b: 64  # type: ignore[assignment]
+        await light.async_turn_on(**{ATTR_BRIGHTNESS: 64})
+        hub.async_send_command.assert_not_called()
+
+
+class TestAsyncTurnOff:
+    async def test_dispatches_off_button(self) -> None:
+        light, hub = _make_light()
+        light._attr_is_on = True
+        light._attr_brightness = 255
+        await light.async_turn_off()
+        hub.async_send_command.assert_awaited_once_with(7, OFF_BUTTON_CODE)
+        assert light.is_on is False
+        assert light.brightness == 0
+
+    async def test_no_op_when_off_button_not_learned(self) -> None:
+        # 0 is removed from the brightness_to_button map when off button isn't learned.
+        partial = {1: True, 2: True, 3: True, 4: True, OFF_BUTTON_CODE: False}
+        light, hub = _make_light(learned=partial)
+        light._attr_is_on = True
+        await light.async_turn_off()
+        hub.async_send_command.assert_not_called()
+        # State stays on — the off command couldn't be sent.
+        assert light.is_on is True
+
+
+def test_discrete_brightness_levels_constant() -> None:
+    # Pin the module-level mapping that documents the discrete LUT.
+    assert DISCRETE_BRIGHTNESS_LEVELS == {
+        0: "Off",
+        64: "25",
+        128: "50",
+        191: "75",
+        255: "100",
+    }

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,271 @@
+"""Tests for the Bromic protocol encoding / decoding layer.
+
+The protocol is the most testable piece of the integration: pure functions
+operating on bytes. These tests pin down the wire-format behavior — exactly
+what bytes go out for a given (id, button), how each response shape is
+classified (ACK / error / unknown), checksum validation, and the round-trip
+through `parse_hex_command`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.bromic_smart_heat_link.const import (
+    ACK_RESPONSE,
+    COMMAND_BYTE,
+    ERROR_CODES,
+    ERROR_COMMAND,
+    MAX_BUTTON_CODE,
+    MAX_ID_LOCATION,
+)
+from custom_components.bromic_smart_heat_link.exceptions import (
+    BromicChecksumError,
+    BromicInvalidResponseError,
+    BromicProtocolError,
+)
+from custom_components.bromic_smart_heat_link.protocol import (
+    BromicCommand,
+    BromicProtocol,
+    BromicResponse,
+)
+
+
+class TestCalculateChecksum:
+    """`calculate_checksum` is a sum-mod-256 over the input bytes."""
+
+    def test_empty_returns_zero(self) -> None:
+        assert BromicProtocol.calculate_checksum(b"") == 0
+
+    def test_single_byte(self) -> None:
+        assert BromicProtocol.calculate_checksum(bytes([0x42])) == 0x42
+
+    def test_known_canonical_frame(self) -> None:
+        # The docstring example "540001000156" decomposes as T+ID(0001)+BTN(0001)+CK(56).
+        # Checksum over the first 5 bytes: 0x54 + 0x00 + 0x01 + 0x00 + 0x01 = 0x56.
+        data = bytes([0x54, 0x00, 0x01, 0x00, 0x01])
+        assert BromicProtocol.calculate_checksum(data) == 0x56
+
+    def test_wraps_mod_256(self) -> None:
+        # 0xFF + 0xFF = 0x1FE → 0xFE after mod 256.
+        assert BromicProtocol.calculate_checksum(bytes([0xFF, 0xFF])) == 0xFE
+
+    def test_all_ones_wraps_to_zero(self) -> None:
+        # 256 * 0x01 = 0x100 → 0x00 after mod 256.
+        assert BromicProtocol.calculate_checksum(bytes([0x01] * 256)) == 0x00
+
+
+class TestEncodeCommand:
+    """`encode_command` produces a 6-byte frame: T + ID(big-endian, 2B) + BTN(2B) + checksum."""
+
+    def test_minimum_id_minimum_button(self) -> None:
+        cmd = BromicProtocol.encode_command(1, 1)
+        assert isinstance(cmd, BromicCommand)
+        assert cmd.id_location == 1
+        assert cmd.button_code == 1
+        assert cmd.raw_bytes == bytes([0x54, 0x00, 0x01, 0x00, 0x01, 0x56])
+        assert len(cmd.raw_bytes) == 6
+
+    def test_id_byte_layout_is_big_endian_two_bytes(self) -> None:
+        # Legal IDs are 1..50 — they fit in 1 byte. The protocol still
+        # reserves 2 bytes for ID, with the high byte zeroed.
+        cmd = BromicProtocol.encode_command(25, 4)
+        assert cmd.raw_bytes[1] == 0x00  # high byte
+        assert cmd.raw_bytes[2] == 25  # low byte
+
+    def test_button_byte_layout_is_big_endian_two_bytes(self) -> None:
+        # Legal buttons are 1..8 — also single-byte values. Verify the
+        # 2-byte big-endian slot is laid out correctly.
+        cmd = BromicProtocol.encode_command(1, 7)
+        assert cmd.raw_bytes[3] == 0x00  # high byte
+        assert cmd.raw_bytes[4] == 7  # low byte
+
+    def test_checksum_is_last_byte(self) -> None:
+        cmd = BromicProtocol.encode_command(25, 4)
+        expected_ck = BromicProtocol.calculate_checksum(cmd.raw_bytes[:-1])
+        assert cmd.raw_bytes[-1] == expected_ck
+
+    def test_max_id_max_button(self) -> None:
+        cmd = BromicProtocol.encode_command(MAX_ID_LOCATION, MAX_BUTTON_CODE)
+        assert cmd.id_location == MAX_ID_LOCATION
+        assert cmd.button_code == MAX_BUTTON_CODE
+        # Frame validates against the round-trip.
+        assert BromicProtocol.validate_frame(cmd.raw_bytes) is True
+
+    @pytest.mark.parametrize("bad_id", [0, -1, MAX_ID_LOCATION + 1, 1000])
+    def test_invalid_id_raises(self, bad_id: int) -> None:
+        with pytest.raises(BromicProtocolError, match="Invalid ID location"):
+            BromicProtocol.encode_command(bad_id, 1)
+
+    @pytest.mark.parametrize("bad_btn", [0, -1, MAX_BUTTON_CODE + 1, 1000])
+    def test_invalid_button_raises(self, bad_btn: int) -> None:
+        with pytest.raises(BromicProtocolError, match="Invalid button code"):
+            BromicProtocol.encode_command(1, bad_btn)
+
+    def test_off_button_code_8_accepted(self) -> None:
+        # OFF_BUTTON_CODE = 8 must be in range [1, MAX_BUTTON_CODE].
+        cmd = BromicProtocol.encode_command(1, 8)
+        assert cmd.button_code == 8
+
+
+class TestDecodeResponse:
+    """`decode_response` classifies inbound bytes into ACK / error / unknown / invalid."""
+
+    def test_ack_response_is_success(self) -> None:
+        resp = BromicProtocol.decode_response(ACK_RESPONSE)
+        assert isinstance(resp, BromicResponse)
+        assert resp.success is True
+        assert resp.error_code is None
+        assert resp.raw_bytes == ACK_RESPONSE
+
+    def test_empty_data_raises_invalid(self) -> None:
+        with pytest.raises(BromicInvalidResponseError, match="Empty response"):
+            BromicProtocol.decode_response(b"")
+
+    def test_too_short_raises_invalid(self) -> None:
+        # Less than MIN_STD_RESPONSE_LENGTH (3) and not ACK / not error.
+        with pytest.raises(BromicInvalidResponseError, match="Response too short"):
+            BromicProtocol.decode_response(bytes([0x00, 0x00]))
+
+    @pytest.mark.parametrize("error_code", sorted(ERROR_CODES))
+    def test_each_documented_error_code(self, error_code: int) -> None:
+        # 'E' + code + filler byte, total 3 bytes — the error-response shape.
+        data = bytes([ERROR_COMMAND, error_code, 0x00])
+        resp = BromicProtocol.decode_response(data)
+        assert resp.success is False
+        assert resp.error_code == error_code
+        assert resp.message == ERROR_CODES[error_code]
+        assert resp.raw_bytes == data
+
+    def test_unknown_error_code_falls_back_to_hex_string(self) -> None:
+        # 0xFE is not in ERROR_CODES; message includes the hex.
+        data = bytes([ERROR_COMMAND, 0xFE, 0x00])
+        resp = BromicProtocol.decode_response(data)
+        assert resp.success is False
+        assert resp.error_code == 0xFE
+        assert "FE" in resp.message
+
+    def test_checksum_mismatch_raises(self) -> None:
+        # 4-byte frame starting with neither ACK nor 'E'. Bad checksum.
+        data = bytes([0x99, 0x01, 0x02, 0xAA])  # checksum should be 0x9C, not 0xAA
+        with pytest.raises(BromicChecksumError, match="Checksum mismatch"):
+            BromicProtocol.decode_response(data)
+
+    def test_unknown_response_with_valid_checksum_is_failure_but_no_error_code(
+        self,
+    ) -> None:
+        # Build a frame that's neither ACK nor an error response shape, with a
+        # valid checksum, so decode_response classifies it as "unknown".
+        body = bytes([0x99, 0x01])
+        ck = BromicProtocol.calculate_checksum(body)
+        good_frame = body + bytes([ck])
+        resp = BromicProtocol.decode_response(good_frame)
+        # Not ACK, not error-shape, but checksum valid → unknown but not raise.
+        assert resp.success is False
+        assert resp.error_code is None
+        assert "Unknown response" in resp.message
+
+
+class TestValidateFrame:
+    """`validate_frame` returns True iff frame is well-formed and checksum matches."""
+
+    def test_round_trip_with_encode_command(self) -> None:
+        cmd = BromicProtocol.encode_command(10, 3)
+        assert BromicProtocol.validate_frame(cmd.raw_bytes) is True
+
+    def test_too_short_is_false(self) -> None:
+        assert BromicProtocol.validate_frame(bytes([0x54, 0x00, 0x01])) is False
+
+    def test_wrong_command_byte_is_false(self) -> None:
+        # Frame is 6 bytes with valid checksum but wrong command byte.
+        body = bytes([0x00, 0x00, 0x01, 0x00, 0x01])
+        ck = BromicProtocol.calculate_checksum(body)
+        frame = body + bytes([ck])
+        assert BromicProtocol.validate_frame(frame) is False
+
+    def test_bad_checksum_is_false(self) -> None:
+        # 6-byte frame, command byte right, checksum wrong.
+        bad = bytes([COMMAND_BYTE, 0x00, 0x01, 0x00, 0x01, 0xAA])
+        assert BromicProtocol.validate_frame(bad) is False
+
+    def test_empty_is_false(self) -> None:
+        assert BromicProtocol.validate_frame(b"") is False
+
+
+class TestGetCommandExamples:
+    """`get_command_examples` returns hex strings for the first few IDs × buttons."""
+
+    def test_returns_dict_of_dicts(self) -> None:
+        examples = BromicProtocol.get_command_examples()
+        assert isinstance(examples, dict)
+        assert all(isinstance(v, dict) for v in examples.values())
+
+    def test_covers_first_four_ids(self) -> None:
+        examples = BromicProtocol.get_command_examples()
+        assert set(examples.keys()) == {1, 2, 3, 4}
+
+    def test_each_example_round_trips(self) -> None:
+        examples = BromicProtocol.get_command_examples()
+        for id_loc, buttons in examples.items():
+            for button, hex_str in buttons.items():
+                parsed = BromicProtocol.parse_hex_command(hex_str)
+                assert parsed is not None, (
+                    f"Round-trip failed for ID={id_loc}, Button={button}"
+                )
+                assert parsed.id_location == id_loc
+                assert parsed.button_code == button
+
+
+class TestParseHexCommand:
+    """`parse_hex_command` is the inverse of `encode_command` for valid frames."""
+
+    def test_canonical_round_trip(self) -> None:
+        cmd = BromicProtocol.encode_command(1, 1)
+        parsed = BromicProtocol.parse_hex_command(cmd.raw_bytes.hex())
+        assert parsed is not None
+        assert parsed.id_location == 1
+        assert parsed.button_code == 1
+        assert parsed.raw_bytes == cmd.raw_bytes
+
+    def test_uppercase_hex_works(self) -> None:
+        parsed = BromicProtocol.parse_hex_command("540001000156")
+        assert parsed is not None
+        assert parsed.id_location == 1
+
+    def test_with_spaces_works(self) -> None:
+        parsed = BromicProtocol.parse_hex_command("54 00 01 00 01 56")
+        assert parsed is not None
+        assert parsed.id_location == 1
+
+    def test_with_colons_works(self) -> None:
+        parsed = BromicProtocol.parse_hex_command("54:00:01:00:01:56")
+        assert parsed is not None
+        assert parsed.id_location == 1
+
+    def test_wrong_length_returns_none(self) -> None:
+        # 5 bytes, not 6.
+        assert BromicProtocol.parse_hex_command("5400010001") is None
+
+    def test_wrong_command_byte_returns_none(self) -> None:
+        # 6-byte frame, valid checksum, but starts with 0x00 not 0x54.
+        body = bytes([0x00, 0x00, 0x01, 0x00, 0x01])
+        ck = BromicProtocol.calculate_checksum(body)
+        bad = (body + bytes([ck])).hex()
+        assert BromicProtocol.parse_hex_command(bad) is None
+
+    def test_bad_checksum_returns_none(self) -> None:
+        # First 5 bytes correct, last byte wrong.
+        assert BromicProtocol.parse_hex_command("5400010001FF") is None
+
+    def test_non_hex_returns_none(self) -> None:
+        assert BromicProtocol.parse_hex_command("not hex at all") is None
+
+    def test_empty_returns_none(self) -> None:
+        assert BromicProtocol.parse_hex_command("") is None
+
+    def test_round_trips_high_id_and_button(self) -> None:
+        cmd = BromicProtocol.encode_command(MAX_ID_LOCATION, MAX_BUTTON_CODE)
+        parsed = BromicProtocol.parse_hex_command(cmd.raw_bytes.hex())
+        assert parsed is not None
+        assert parsed.id_location == MAX_ID_LOCATION
+        assert parsed.button_code == MAX_BUTTON_CODE

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,185 @@
+"""Tests for the three integration services.
+
+Covers `learn_button`, `clear_controller`, and `send_raw_command`. Each
+service finds the first connected hub and dispatches through it; tests
+mock the hub and assert the expected dispatch behavior + the
+`ServiceValidationError` paths.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.exceptions import ServiceValidationError
+
+from custom_components.bromic_smart_heat_link.const import (
+    ATTR_BUTTON_NUMBER,
+    ATTR_ID_LOCATION,
+    ATTR_RAW_COMMAND,
+    DOMAIN,
+    SERVICE_CLEAR_CONTROLLER,
+    SERVICE_LEARN_BUTTON,
+    SERVICE_SEND_RAW_COMMAND,
+)
+from custom_components.bromic_smart_heat_link.protocol import (
+    BromicProtocol,
+    BromicResponse,
+)
+from custom_components.bromic_smart_heat_link.services import (
+    _get_hub,
+    async_remove_services,
+    async_setup_services,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+def _install_connected_hub(
+    hass: HomeAssistant, *, send_result: BromicResponse | None = None
+) -> MagicMock:
+    if send_result is None:
+        send_result = BromicResponse(
+            success=True, error_code=None, message="ok", raw_bytes=b""
+        )
+    hub = MagicMock(name="hub")
+    hub.connected = True
+    hub.async_send_command = AsyncMock(return_value=send_result)
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN]["test_entry"] = {"hub": hub}
+    return hub
+
+
+class TestGetHub:
+    """`_get_hub` returns the first connected hub or None."""
+
+    def test_returns_none_when_domain_data_missing(self, hass: HomeAssistant) -> None:
+        # hass.data is empty.
+        assert _get_hub(hass) is None
+
+    def test_returns_none_when_no_hub_connected(self, hass: HomeAssistant) -> None:
+        hub = MagicMock()
+        hub.connected = False
+        hass.data[DOMAIN] = {"entry": {"hub": hub}}
+        assert _get_hub(hass) is None
+
+    def test_returns_first_connected_hub(self, hass: HomeAssistant) -> None:
+        hub = _install_connected_hub(hass)
+        assert _get_hub(hass) is hub
+
+
+class TestRegistration:
+    """`async_setup_services` registers exactly 3 services."""
+
+    async def test_registers_three_services(self, hass: HomeAssistant) -> None:
+        await async_setup_services(hass)
+        assert hass.services.has_service(DOMAIN, SERVICE_LEARN_BUTTON)
+        assert hass.services.has_service(DOMAIN, SERVICE_CLEAR_CONTROLLER)
+        assert hass.services.has_service(DOMAIN, SERVICE_SEND_RAW_COMMAND)
+
+    async def test_remove_services_unregisters(self, hass: HomeAssistant) -> None:
+        await async_setup_services(hass)
+        await async_remove_services(hass)
+        assert not hass.services.has_service(DOMAIN, SERVICE_LEARN_BUTTON)
+        assert not hass.services.has_service(DOMAIN, SERVICE_CLEAR_CONTROLLER)
+        assert not hass.services.has_service(DOMAIN, SERVICE_SEND_RAW_COMMAND)
+
+
+class TestLearnButton:
+    async def test_success_dispatches_to_hub(self, hass: HomeAssistant) -> None:
+        hub = _install_connected_hub(hass)
+        await async_setup_services(hass)
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_LEARN_BUTTON,
+            {ATTR_ID_LOCATION: 5, ATTR_BUTTON_NUMBER: 1},
+            blocking=True,
+        )
+
+        hub.async_send_command.assert_awaited_once_with(5, 1)
+
+    async def test_no_hub_raises_validation_error(self, hass: HomeAssistant) -> None:
+        await async_setup_services(hass)
+        with pytest.raises(ServiceValidationError, match="No Bromic device"):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_LEARN_BUTTON,
+                {ATTR_ID_LOCATION: 5, ATTR_BUTTON_NUMBER: 1},
+                blocking=True,
+            )
+
+    async def test_failed_response_raises(self, hass: HomeAssistant) -> None:
+        bad = BromicResponse(
+            success=False, error_code=0x02, message="Wrong command", raw_bytes=b""
+        )
+        _install_connected_hub(hass, send_result=bad)
+        await async_setup_services(hass)
+        with pytest.raises(ServiceValidationError, match="Learning failed"):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_LEARN_BUTTON,
+                {ATTR_ID_LOCATION: 5, ATTR_BUTTON_NUMBER: 1},
+                blocking=True,
+            )
+
+
+class TestClearController:
+    async def test_always_raises_not_implemented(self, hass: HomeAssistant) -> None:
+        # The Bromic protocol doesn't expose a "clear" command, so the
+        # service surfaces an explicit ServiceValidationError.
+        _install_connected_hub(hass)
+        await async_setup_services(hass)
+        with pytest.raises(ServiceValidationError, match="not available"):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_CLEAR_CONTROLLER,
+                {ATTR_ID_LOCATION: 5},
+                blocking=True,
+            )
+
+
+class TestSendRawCommand:
+    async def test_valid_hex_dispatches_to_hub(self, hass: HomeAssistant) -> None:
+        hub = _install_connected_hub(hass)
+        await async_setup_services(hass)
+
+        # Build a real round-trippable hex command for (ID=1, button=1).
+        cmd = BromicProtocol.encode_command(1, 1)
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SEND_RAW_COMMAND,
+            {ATTR_RAW_COMMAND: cmd.raw_bytes.hex()},
+            blocking=True,
+        )
+
+        hub.async_send_command.assert_awaited_once_with(1, 1)
+
+    async def test_invalid_hex_raises(self, hass: HomeAssistant) -> None:
+        _install_connected_hub(hass)
+        await async_setup_services(hass)
+        with pytest.raises(ServiceValidationError, match="Invalid raw command"):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_SEND_RAW_COMMAND,
+                {ATTR_RAW_COMMAND: "not-a-hex-frame"},
+                blocking=True,
+            )
+
+    async def test_failed_response_raises(self, hass: HomeAssistant) -> None:
+        bad = BromicResponse(
+            success=False, error_code=0x02, message="Wrong command", raw_bytes=b""
+        )
+        _install_connected_hub(hass, send_result=bad)
+        await async_setup_services(hass)
+        cmd = BromicProtocol.encode_command(1, 1)
+        with pytest.raises(ServiceValidationError, match="Command failed"):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_SEND_RAW_COMMAND,
+                {ATTR_RAW_COMMAND: cmd.raw_bytes.hex()},
+                blocking=True,
+            )

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,105 @@
+"""Tests for `BromicSwitch` — the ON/OFF controller entity.
+
+Covers turn_on / turn_off dispatch to the right button code, the
+extra_state_attributes augmentation (on_button / off_button / names),
+and the "no state change on failed command" behavior.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.bromic_smart_heat_link.protocol import BromicResponse
+from custom_components.bromic_smart_heat_link.switch import BromicSwitch
+
+
+def _make_switch(
+    *,
+    on_button: int = 1,
+    off_button: int = 2,
+    send_result: BromicResponse | None = None,
+) -> tuple[BromicSwitch, MagicMock]:
+    hub = MagicMock(name="hub")
+    hub.port = "/dev/ttyUSB0"
+    hub.stats = {"last_success": 0.0}
+    if send_result is None:
+        send_result = BromicResponse(
+            success=True, error_code=None, message="ok", raw_bytes=b""
+        )
+    hub.async_send_command = AsyncMock(return_value=send_result)
+
+    switch = BromicSwitch(
+        hub=hub,
+        id_location=5,
+        controller_type="onoff",
+        on_button=on_button,
+        off_button=off_button,
+    )
+    # Disable `async_write_ha_state` so we don't need an attached hass.
+    switch.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
+    return switch, hub
+
+
+class TestInitialState:
+    """A freshly-constructed switch is off, assumes its state, and reports button mappings."""
+
+    def test_starts_off(self) -> None:
+        switch, _ = _make_switch()
+        assert switch.is_on is False
+
+    def test_assumed_state_is_true(self) -> None:
+        # The bridge sends no telemetry; switch state is assumed.
+        switch, _ = _make_switch()
+        assert switch.assumed_state is True
+
+    def test_extra_state_attributes_includes_button_assignments(self) -> None:
+        switch, _ = _make_switch(on_button=1, off_button=2)
+        attrs = switch.extra_state_attributes
+        assert attrs["on_button"] == 1
+        assert attrs["off_button"] == 2
+        assert attrs["button_names"][1] == "ON"
+        assert attrs["button_names"][2] == "OFF"
+
+
+class TestAsyncTurnOn:
+    async def test_dispatches_on_button(self) -> None:
+        switch, hub = _make_switch(on_button=1)
+        await switch.async_turn_on()
+        hub.async_send_command.assert_awaited_once_with(5, 1)
+        assert switch.is_on is True
+
+    async def test_does_not_flip_state_on_failed_response(self) -> None:
+        bad = BromicResponse(
+            success=False, error_code=0x02, message="Wrong command", raw_bytes=b""
+        )
+        switch, _ = _make_switch(send_result=bad)
+        assert switch.is_on is False
+        await switch.async_turn_on()
+        # State NOT flipped — the device didn't confirm.
+        assert switch.is_on is False
+
+    async def test_kwargs_ignored(self) -> None:
+        # HA may pass arbitrary kwargs (transition, etc.) — the switch should ignore them.
+        switch, hub = _make_switch()
+        await switch.async_turn_on(transition=1.5, extra="ignored")
+        hub.async_send_command.assert_awaited_once()
+
+
+class TestAsyncTurnOff:
+    async def test_dispatches_off_button(self) -> None:
+        switch, hub = _make_switch(on_button=1, off_button=2)
+        # Pre-set to on so we can observe the flip.
+        switch._attr_is_on = True
+        await switch.async_turn_off()
+        hub.async_send_command.assert_awaited_once_with(5, 2)
+        assert switch.is_on is False
+
+    async def test_does_not_flip_state_on_failed_response(self) -> None:
+        bad = BromicResponse(
+            success=False, error_code=0x02, message="Wrong command", raw_bytes=b""
+        )
+        switch, _ = _make_switch(send_result=bad)
+        switch._attr_is_on = True
+        await switch.async_turn_off()
+        # Still "on" because the off command didn't take.
+        assert switch.is_on is True


### PR DESCRIPTION
## Summary
Adds **163 new tests** across every public module of the integration, bringing total coverage from 1 smoke test → 164 tests. Strictly additive — **no code under `custom_components/bromic_smart_heat_link/` was modified**. The suite is meant as the go/no-go for the next bromic release.

## Coverage by module
| File | Tests | What |
|---|---:|---|
| `test_protocol.py` | 31 | encode/decode/checksum, every documented error code, parse_hex_command round-trips, validate_frame edge cases |
| `test_exceptions.py` | 16 | full inheritance hierarchy + `BromicCommandError.error_code` attribute |
| `test_const.py` | 16 | protocol bytes, serial config, brightness LUT, error-code table, learning sequence, ID range, safety-critical retry bound |
| `test_hub.py` | 19 | mocked `serial.Serial`: connect/disconnect, callback fan-out + exception isolation, command stats, retry semantics, `async_test_connection` |
| `test_entity.py` | 12 | identifier munging, device_info shape, stats attributes, success/failure/exception command paths, connection callback |
| `test_switch.py` | 8 | turn_on/turn_off button dispatch, no-state-change on failed response |
| `test_light.py` | 17 | brightness-to-button mapping, closest-match discrete level selection, turn_on/off flows, unlearned-button no-op |
| `test_services.py` | 12 | service registration, hub selection, all three services' happy + error paths |
| `test_diagnostics.py` | 4 | payload shape, port redaction, hub stats, controller summary |
| `test_config_flow.py` | 4 | user-step form, successful selection, failed connection surfaces error, manual port |

## Test infra
- `requirements.txt`: adds `pyserial>=3.5` so the dev env matches what `manifest.json` already declares for production. The existing `serial==0.0.97` is a deprecated alias and doesn't actually provide `serial.Serial`.
- `.ruff.toml`: expanded `[lint.per-file-ignores]` for `tests/**` covering the usual test idioms (asserts, fixture injection, docstring relaxations, line-length for descriptive comments).

## Surfaced production bug (NOT fixed here)
While writing the diagnostics tests, I found that **`diagnostics.py:43` uses the removed `hass.helpers.entity_registry.async_get(hass)` API**. Under HA 2026.4.4 (current pin) the diagnostics endpoint will raise `AttributeError`. The tests mock around it to exercise the rest of the payload shape. **Worth a separate small follow-up PR** to switch to:

```python
from homeassistant.helpers import entity_registry as er
entity_registry = er.async_get(hass)
```

I left it out of this PR to honor the tests-only constraint.

## Test plan
- Pre-commit hooks pass locally (ruff check + format, EOF/whitespace, etc.).
- All 163 new tests pass locally in the devcontainer (`pytest tests/` → `163 passed in ~5s`).
- CI on this branch should run all 164 (1 smoke + 163 new) and stay green.

## After merge
- You take the test-validated code to your production HA / real Bromic bridge.
- If it works, cut the first CalVer release: **`Bromic v<YYYY>.<M>.<DD>`** per the new fleet convention.