### PR TITLE
fix: drop alias-serial shadow + modernize diagnostics for HA 2026.4.x

### DIFF
--- a/custom_components/bromic_smart_heat_link/diagnostics.py
+++ b/custom_components/bromic_smart_heat_link/diagnostics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.helpers import entity_registry as er
 
 from .const import CONF_SERIAL_PORT, DOMAIN
 
@@ -40,7 +41,7 @@ async def async_get_config_entry_diagnostics(
         }
 
     # Collect entity information
-    entity_registry = hass.helpers.entity_registry.async_get(hass)
+    entity_registry = er.async_get(hass)
     entities = [
         {
             "entity_id": entity_entry.entity_id,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ homeassistant==2026.4.4
 pip>=26.1.1
 ruff==0.15.12
 pre_commit==4.6.0
-serial==0.0.97
 pyserial>=3.5
 pytest-homeassistant-custom-component==0.13.325

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -4,14 +4,6 @@ Critical assertions:
 - The serial port is redacted (it can contain identifying USB IDs).
 - Hub stats are surfaced.
 - Controller metadata is summarized (type + learned button count).
-
-**Known production bug** (discovered while writing these tests, not fixed
-here per the tests-only constraint): `diagnostics.py:43` uses
-`hass.helpers.entity_registry.async_get(hass)` — the deprecated/removed
-HA helpers API. Under HA 2026.4.4, this raises `AttributeError`. These
-tests mock `hass.helpers` to exercise the rest of the payload shape; the
-real diagnostics endpoint would crash in production. Tracked separately
-for a follow-up fix.
 """
 
 from __future__ import annotations
@@ -54,13 +46,6 @@ async def test_serial_port_redacted_in_data(hass: HomeAssistant) -> None:
     hub.stats = {"commands_sent": 5}
     hass.data[DOMAIN] = {entry.entry_id: {"hub": hub}}
 
-    # Mock the deprecated hass.helpers.entity_registry path that diagnostics.py
-    # still calls. See module-level docstring; this is a known production bug.
-    fake_registry = MagicMock()
-    fake_registry.entities.values.return_value = []
-    hass.helpers = MagicMock()
-    hass.helpers.entity_registry.async_get.return_value = fake_registry
-
     diag = await async_get_config_entry_diagnostics(hass, entry)
     # Redacted form is **REDACTED** (HA's standard sentinel).
     assert diag["config_entry"]["data"][CONF_SERIAL_PORT] != "/dev/ttyUSB0"
@@ -80,13 +65,6 @@ async def test_hub_port_redacted_in_hub_section(hass: HomeAssistant) -> None:
     hub.port = "/dev/ttyUSB0"
     hub.stats = {"commands_sent": 0}
     hass.data[DOMAIN] = {entry.entry_id: {"hub": hub}}
-
-    # Mock the deprecated hass.helpers.entity_registry path that diagnostics.py
-    # still calls. See module-level docstring; this is a known production bug.
-    fake_registry = MagicMock()
-    fake_registry.entities.values.return_value = []
-    hass.helpers = MagicMock()
-    hass.helpers.entity_registry.async_get.return_value = fake_registry
 
     diag = await async_get_config_entry_diagnostics(hass, entry)
     assert diag["hub"]["port"] != "/dev/ttyUSB0"
@@ -110,13 +88,6 @@ async def test_hub_stats_surface(hass: HomeAssistant) -> None:
         "commands_failed": 2,
     }
     hass.data[DOMAIN] = {entry.entry_id: {"hub": hub}}
-
-    # Mock the deprecated hass.helpers.entity_registry path that diagnostics.py
-    # still calls. See module-level docstring; this is a known production bug.
-    fake_registry = MagicMock()
-    fake_registry.entities.values.return_value = []
-    hass.helpers = MagicMock()
-    hass.helpers.entity_registry.async_get.return_value = fake_registry
 
     diag = await async_get_config_entry_diagnostics(hass, entry)
     assert diag["hub"]["connected"] is True
@@ -157,13 +128,6 @@ async def test_controllers_summary(hass: HomeAssistant) -> None:
     hub.port = "/dev/ttyUSB0"
     hub.stats = {}
     hass.data[DOMAIN] = {entry.entry_id: {"hub": hub}}
-
-    # Mock the deprecated hass.helpers.entity_registry path that diagnostics.py
-    # still calls. See module-level docstring; this is a known production bug.
-    fake_registry = MagicMock()
-    fake_registry.entities.values.return_value = []
-    hass.helpers = MagicMock()
-    hass.helpers.entity_registry.async_get.return_value = fake_registry
 
     diag = await async_get_config_entry_diagnostics(hass, entry)
 


### PR DESCRIPTION
## Summary
Stacked on top of [#72](https://github.com/bharat/homeassistant-bromic-smart-heat-link/pull/72). Two production fixes uncovered by that PR's test suite.

## Fix 1 — drop `serial==0.0.97` from `requirements.txt`
That deprecated alias installs an empty `serial/` namespace directory with no `Serial` attribute. On a fresh runner (no warm site-packages), pip resolves both `serial` and `pyserial` but the alias's leftover namespace wins the import-path race — `import serial; serial.Serial` raises `AttributeError`. That's why #72's CI Pytest job failed:
```
AttributeError: <module 'serial' ...> does not have the attribute 'Serial'
```
AGENTS.md previously noted not to touch this entry without investigation. **This is the investigation.** The alias adds nothing — `pyserial>=3.5` (which manifest.json already requires for production) provides the real `serial` import path. Dropping the alias is the fix.

## Fix 2 — `diagnostics.py` modernization
Replace the removed-in-HA `hass.helpers.entity_registry.async_get(hass)` with the modern module-level import:
```python
from homeassistant.helpers import entity_registry as er
...
entity_registry = er.async_get(hass)
```
Under HA 2026.4.4 the deprecated path raises `AttributeError`. The diagnostics endpoint would crash in production. #72 mocked around it; this commit lets the tests exercise the real code path, so the four mock-injection blocks in `tests/test_diagnostics.py` are gone.

## Verification
All 163 tests still pass:
```
============================= 163 passed in 5.07s ==============================
```

## Merge plan
Merge order:
1. **#72** first (the test suite).
2. **This PR (#73)** second — it'll auto-rebase down to a clean delta against `main` once #72 lands.

After both merge, bromic main is on green CI with a working diagnostics endpoint, the broken alias removed, and 163 tests pinning the integration's behavior.