### PR TITLE
release: bump version to 2026.5.13

### DIFF
--- a/custom_components/bromic_smart_heat_link/manifest.json
+++ b/custom_components/bromic_smart_heat_link/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "pyserial>=3.5"
   ],
-  "version": "0.1.2"
+  "version": "2026.5.13"
 }


### PR DESCRIPTION
## Summary
Bumps `custom_components/bromic_smart_heat_link/manifest.json` from `0.1.2` to `2026.5.13`. First release under the fleet-wide CalVer convention.

## What lands with this release
After merge, I'll tag `v2026.5.13` and create the GitHub release `Bromic v2026.5.13` with the standard fleet release-notes shape.

Bharat verified the new code (HA 2026.4.4 + Python 3.14 + 164-test suite + diagnostics fix) against his real Bromic Smart Heat Link bridge before cutting.