### PR TITLE
Install Claude Code in the devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "bharat/homeassistant-bromic-smart-heat-link",
   "image": "mcr.microsoft.com/devcontainers/python:3.14",
-  "postCreateCommand": "scripts/setup",
+  "postCreateCommand": "scripts/setup && npm install -g @anthropic-ai/claude-code",
   "forwardPorts": [
     8123
   ],
@@ -49,7 +49,8 @@
     },
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
       "moby": false
-    }
+    },
+    "ghcr.io/devcontainers/features/node:2": {}
   },
   "mounts": [
     "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",


### PR DESCRIPTION
Make `claude` (Claude Code CLI) available inside the devcontainer so a session running on the host can dispatch into the container and continue the work there.

## What changed

- Adds the `ghcr.io/devcontainers/features/node:2` feature so npm is present.
- Appends `npm install -g @anthropic-ai/claude-code` to `postCreateCommand` so the CLI is installed on first container build.

## Verified

Rebuilt the container locally with `devcontainer up --remove-existing-container`. The new postCreateCommand:

- ran `scripts/setup` end to end (pip install, act, pre-commit) without regression
- installed `@anthropic-ai/claude-code` (2 packages, ~6 s)

After rebuild:

```
$ which claude
/usr/local/share/nvm/current/bin/claude

$ claude --version
2.1.148 (Claude Code)
```

`~/.claude.json` is already bind-mounted by this devcontainer, so the CLI authenticates against the host's existing session.

## Cost

About 60 s added to the first container build; cached after that. The feature is a no-op for anyone who does not invoke `claude` inside the container.
