### PR TITLE
Install Claude Code in the devcontainer via scripts/setup

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -9,3 +9,5 @@ sudo apt update && sudo apt install -y gh
 python3 -m pip install --upgrade pip -r requirements.txt
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo BINDIR=/usr/local/bin bash
 pre-commit install
+
+curl -fsSL https://claude.ai/install.sh | bash


### PR DESCRIPTION
Add the Claude Code CLI to `scripts/setup` so a fresh devcontainer build has `claude` on PATH at `~/.local/bin/claude`.

Without this, dispatching a Claude session from the orchestrator into this container with `claude -p ...` fails with command-not-found, and the work has to fall back to running on the host (which is less aligned with the convention that toolchain operations run inside the container).

## What changed

- Appends `curl -fsSL https://claude.ai/install.sh | bash` to `scripts/setup`. This is the same line two other repos in the org use.

## Notes

- `~/.claude.json` is already bind-mounted by `.devcontainer/devcontainer.json`, so the installed CLI picks up the host session without re-authenticating.
- No `package.json` or `node_modules` needed; the installer drops a static binary into the user's `~/.local/bin`.
- Takes effect on the next container rebuild (no retroactive install).
